### PR TITLE
Use the word "installation" instead of "install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ site.
 
     # Verify checksums
     $ wp core verify-checksums
-    Success: WordPress install verifies against checksums.
+    Success: WordPress installation verifies against checksums.
 
     # Verify checksums for given WordPress version
     $ wp core verify-checksums --version=4.0
-    Success: WordPress install verifies against checksums.
+    Success: WordPress installation verifies against checksums.
 
     # Verify checksums for given locale
     $ wp core verify-checksums --locale=en_US
-    Success: WordPress install verifies against checksums.
+    Success: WordPress installation verifies against checksums.
 
     # Verify checksums for given locale
     $ wp core verify-checksums --locale=ja
     Warning: File doesn't verify against checksum: wp-includes/version.php
     Warning: File doesn't verify against checksum: readme.html
     Warning: File doesn't verify against checksum: wp-config-sample.php
-    Error: WordPress install doesn't verify against checksums.
+    Error: WordPress installation doesn't verify against checksums.
 
 ## Installing
 

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -9,7 +9,7 @@ Feature: Validate checksums for WordPress install
     When I run `wp core verify-checksums`
     Then STDOUT should be:
       """
-      Success: WordPress install verifies against checksums.
+      Success: WordPress installation verifies against checksums.
       """
 
   Scenario: Core checksums don't verify
@@ -20,7 +20,7 @@ Feature: Validate checksums for WordPress install
     Then STDERR should be:
       """
       Warning: File doesn't verify against checksum: readme.html
-      Error: WordPress install doesn't verify against checksums.
+      Error: WordPress installation doesn't verify against checksums.
       """
 
     When I run `rm readme.html`
@@ -30,7 +30,7 @@ Feature: Validate checksums for WordPress install
     Then STDERR should be:
       """
       Warning: File doesn't exist: readme.html
-      Error: WordPress install doesn't verify against checksums.
+      Error: WordPress installation doesn't verify against checksums.
       """
 
   Scenario: Verify core checksums without loading WordPress
@@ -40,19 +40,19 @@ Feature: Validate checksums for WordPress install
     When I run `wp core verify-checksums`
     Then STDOUT should be:
       """
-      Success: WordPress install verifies against checksums.
+      Success: WordPress installation verifies against checksums.
       """
 
     When I run `wp core verify-checksums --version=4.3 --locale=en_US`
     Then STDOUT should be:
       """
-      Success: WordPress install verifies against checksums.
+      Success: WordPress installation verifies against checksums.
       """
 
     When I try `wp core verify-checksums --version=4.2 --locale=en_US`
     Then STDERR should contain:
       """
-      Error: WordPress install doesn't verify against checksums.
+      Error: WordPress installation doesn't verify against checksums.
       """
 
   Scenario: Verify core checksums for a non US local
@@ -69,7 +69,7 @@ Feature: Validate checksums for WordPress install
     When I try `wp core verify-checksums`
     Then STDOUT should be:
       """
-      Success: WordPress install verifies against checksums.
+      Success: WordPress installation verifies against checksums.
       """
     And the return code should be 0
 
@@ -92,7 +92,7 @@ Feature: Validate checksums for WordPress install
       """
     And STDOUT should be:
       """
-      Success: WordPress install verifies against checksums.
+      Success: WordPress installation verifies against checksums.
       """
     And the return code should be 0
 
@@ -106,6 +106,6 @@ Feature: Validate checksums for WordPress install
     When I run `wp core verify-checksums`
     Then STDOUT should be:
       """
-      Success: WordPress install verifies against checksums.
+      Success: WordPress installation verifies against checksums.
       """
     And STDERR should be empty

--- a/src/Checksum_Command.php
+++ b/src/Checksum_Command.php
@@ -58,22 +58,22 @@ class Checksum_Command extends WP_CLI_Command {
 	 *
 	 *     # Verify checksums
 	 *     $ wp core verify-checksums
-	 *     Success: WordPress install verifies against checksums.
+	 *     Success: WordPress installation verifies against checksums.
 	 *
 	 *     # Verify checksums for given WordPress version
 	 *     $ wp core verify-checksums --version=4.0
-	 *     Success: WordPress install verifies against checksums.
+	 *     Success: WordPress installation verifies against checksums.
 	 *
 	 *     # Verify checksums for given locale
 	 *     $ wp core verify-checksums --locale=en_US
-	 *     Success: WordPress install verifies against checksums.
+	 *     Success: WordPress installation verifies against checksums.
 	 *
 	 *     # Verify checksums for given locale
 	 *     $ wp core verify-checksums --locale=ja
 	 *     Warning: File doesn't verify against checksum: wp-includes/version.php
 	 *     Warning: File doesn't verify against checksum: readme.html
 	 *     Warning: File doesn't verify against checksum: wp-config-sample.php
-	 *     Error: WordPress install doesn't verify against checksums.
+	 *     Error: WordPress installation doesn't verify against checksums.
 	 *
 	 * @when before_wp_load
 	 */
@@ -135,9 +135,9 @@ class Checksum_Command extends WP_CLI_Command {
 		}
 
 		if ( ! $has_errors ) {
-			WP_CLI::success( "WordPress install verifies against checksums." );
+			WP_CLI::success( "WordPress installation verifies against checksums." );
 		} else {
-			WP_CLI::error( "WordPress install doesn't verify against checksums." );
+			WP_CLI::error( "WordPress installation doesn't verify against checksums." );
 		}
 	}
 


### PR DESCRIPTION
As per wp-cli/wp-cli#4541.