### PR TITLE
Warn when files prefixed with 'wp-' are included in WordPress root

### DIFF
--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -96,6 +96,29 @@ Feature: Validate checksums for WordPress install
       """
     And the return code should be 0
 
+    Scenario: Verify core checksums when extra files prefixed with 'wp-' are included in WordPress root
+      Given a WP install
+
+      When I run `wp core update`
+      Then STDOUT should not be empty
+
+      Given a wp-extra-file.php file:
+        """
+        hello world
+        """
+      Then the wp-extra-file.php file should exist
+
+      When I try `wp core verify-checksums`
+      Then STDERR should be:
+        """
+        Warning: File should not exist: wp-extra-file.php
+        """
+      And STDOUT should be:
+        """
+        Success: WordPress installation verifies against checksums.
+        """
+      And the return code should be 0
+
   Scenario: Verify core checksums with a plugin that has wp-admin
     Given a WP install
     And a wp-content/plugins/akismet/wp-admin/extra-file.txt file:

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -98,15 +98,10 @@ Feature: Validate checksums for WordPress install
 
     Scenario: Verify core checksums when extra files prefixed with 'wp-' are included in WordPress root
       Given a WP install
-
-      When I run `wp core update`
-      Then STDOUT should not be empty
-
-      Given a wp-extra-file.php file:
+      And a wp-extra-file.php file:
         """
         hello world
         """
-      Then the wp-extra-file.php file should exist
 
       When I try `wp core verify-checksums`
       Then STDERR should be:

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -138,7 +138,10 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * @return bool
 	 */
 	protected function filter_file( $filepath ) {
-		return ( 0 === strpos( $filepath, 'wp-admin/' ) || 0 === strpos( $filepath, 'wp-includes/' ) );
+		return ( 0 === strpos( $filepath, 'wp-admin/' )
+			|| 0 === strpos( $filepath, 'wp-includes/' )
+			|| 1 === preg_match( '/^wp-(?!config\.php)([^\/]*)$/', $filepath )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #13 

This modification will check for files prefixed with `wp-` in the WordPress root folder, excluding `wp-config.php`, which of course is expected.
I used a regex (`preg_match`) to perform the check, and in particular:

- `(?!config\.php)` excludes `wp-config.php`
- `([^\/]*)` excludes files in subfolders prefixed with `wp-`

I could have used a single `preg_match` also for the `wp-includes` and `wp-admin` folders, but `strpos` is more performant, and this way the `preg_match` is called only when both `strpos` calls return non-zero values. Also, this way the code is more readable.