### PR TITLE
v1.0.6 prerelease: require wp-cli/wp-cli ^1.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {},
     "require-dev": {
         "behat/behat": "~2.5",
-        "wp-cli/wp-cli": "*"
+        "wp-cli/wp-cli": "^1.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Update wp-cli/wp-cli require before releasing 1.0.6.