### PR TITLE
Ensure that plugins cannot evade the checksum verification

### DIFF
--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -1,6 +1,8 @@
 <?php
 
-use \WP_CLI\Utils;
+use WP_CLI\Fetchers;
+use WP_CLI\Formatter;
+use WP_CLI\Utils;
 
 /**
  * Verifies plugin file integrity by comparing to published checksums.
@@ -59,9 +61,9 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 	 */
 	public function __invoke( $args, $assoc_args ) {
 
-		$fetcher = new \WP_CLI\Fetchers\Plugin();
-		$all     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'all', false );
-		$strict  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'strict', false );
+		$fetcher = new Fetchers\UnfilteredPlugin();
+		$all     = Utils\get_flag_value( $assoc_args, 'all', false );
+		$strict  = Utils\get_flag_value( $assoc_args, 'strict', false );
 		$plugins = $fetcher->get_many( $all ? $this->get_all_plugin_names() : $args );
 
 		if ( empty( $plugins ) && ! $all ) {
@@ -113,7 +115,7 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 		}
 
 		if ( ! empty( $this->errors ) ) {
-			$formatter = new \WP_CLI\Formatter(
+			$formatter = new Formatter(
 				$assoc_args,
 				array( 'plugin_name', 'file', 'message' )
 			);
@@ -124,7 +126,7 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 		$failures  = count( array_unique( array_column( $this->errors, 'plugin_name' ) ) );
 		$successes = $total - $failures - $skips;
 
-		\WP_CLI\Utils\report_batch_operation_results(
+		Utils\report_batch_operation_results(
 			'plugin',
 			'verify',
 			$total,

--- a/src/WP_CLI/Fetchers/UnfilteredPlugin.php
+++ b/src/WP_CLI/Fetchers/UnfilteredPlugin.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP_CLI\Fetchers;
+
+/**
+ * Fetch a WordPress plugin based on one of its attributes.
+ *
+ * This is a special version of the plugin fetcher. It doesn't use the
+ * `all_plugins` filter, so that plugins cannot hide themselves from the
+ * checks.
+ *
+ */
+class UnfilteredPlugin extends Base {
+
+	/**
+	 * @var string $msg Error message to use when invalid data is provided
+	 */
+	protected $msg = "The '%s' plugin could not be found.";
+
+	/**
+	 * Get a plugin object by name.
+	 *
+	 * @param string $name
+	 *
+	 * @return object|false
+	 */
+	public function get( $name ) {
+		foreach ( get_plugins() as $file => $_ ) {
+			if ( $file === "$name.php" ||
+				( $name && $file === $name ) ||
+				( dirname( $file ) === $name && $name !== '.' ) ) {
+				return (object) compact( 'name', 'file' );
+			}
+		}
+
+		return false;
+	}
+}
+


### PR DESCRIPTION
As it turned out, the `Fetchers\Plugin` already included the `all_plugins` filter, which allowed plugins to filter themselves out.