### PR TITLE
Use hooks to make sure commands are added at the right moment

### DIFF
--- a/checksum-command.php
+++ b/checksum-command.php
@@ -9,5 +9,10 @@ if ( file_exists( $autoload ) ) {
 	require_once $autoload;
 }
 
-WP_CLI::add_command( 'core verify-checksums', 'Checksum_Core_Command' );
-WP_CLI::add_command( 'plugin verify-checksums', 'Checksum_Plugin_Command' );
+WP_CLI::add_hook( 'after_add_command:core', function () {
+	WP_CLI::add_command( 'core verify-checksums', 'Checksum_Core_Command' );
+} );
+
+WP_CLI::add_hook( 'after_add_command:plugin', function () {
+	WP_CLI::add_command( 'plugin verify-checksums', 'Checksum_Plugin_Command' );
+} );


### PR DESCRIPTION
Somehow, the `core verify-checksums` command does not work through the automatic command dependency resolution, so we manage this manually.

Related: https://github.com/wp-cli/core-command/pull/63