### PR TITLE
Fixing issue #35 - adding backslash to the regex for matching Windows paths correctly

### DIFF
--- a/src/Checksum_Base_Command.php
+++ b/src/Checksum_Base_Command.php
@@ -10,6 +10,17 @@ use \WP_CLI\Utils;
 class Checksum_Base_Command extends WP_CLI_Command {
 
 	/**
+	 * Normalizes directory separators to slashes.
+	 *
+	 * @param string $path Path to convert.
+	 *
+	 * @return string Path with all backslashes replaced by slashes.
+	 */
+	public static function normalize_directory_separators( $path ) {
+		return str_replace( '\\', '/', $path );
+	}
+
+	/**
 	 * Read a remote file and return its contents.
 	 *
 	 * @param string $url URL of the remote file to read.
@@ -42,7 +53,7 @@ class Checksum_Base_Command extends WP_CLI_Command {
 				RecursiveIteratorIterator::CHILD_FIRST
 			);
 			foreach ( $files as $file_info ) {
-				$pathname = substr( $file_info->getPathname(), strlen( $path ) );
+				$pathname = self::normalize_directory_separators( substr( $file_info->getPathname(), strlen( $path ) ) );
 				if ( $file_info->isFile() && $this->filter_file( $pathname ) ) {
 					$filtered_files[] = $pathname;
 				}

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -140,7 +140,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	protected function filter_file( $filepath ) {
 		return ( 0 === strpos( $filepath, 'wp-admin/' )
 			|| 0 === strpos( $filepath, 'wp-includes/' )
-			|| 1 === preg_match( '/^wp-(?!config\.php)([^\/]*)$/', $filepath )
+			|| 1 === preg_match( '/^wp-(?!config\.php)([^\/\\\\]*)$/', $filepath )
 		);
 	}
 

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -140,7 +140,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	protected function filter_file( $filepath ) {
 		return ( 0 === strpos( $filepath, 'wp-admin/' )
 			|| 0 === strpos( $filepath, 'wp-includes/' )
-			|| 1 === preg_match( '/^wp-(?!config\.php)([^\/\\\\]*)$/', $filepath )
+			|| 1 === preg_match( '/^wp-(?!config\.php)([^\/]*)$/', $filepath )
 		);
 	}
 


### PR DESCRIPTION
This solves the issue on Windows.
It's funny how backslash should be escaped, but here's a reference why that's so: https://www.developwebsites.net/match-backslash-preg_match-php/ 