### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/checksum-command.php
+++ b/checksum-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_checksum_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_checksum_autoloader ) ) {
+	require_once $wpcli_checksum_autoloader;
 }
 
 WP_CLI::add_command( 'core', 'Core_Command_Namespace' );

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/extension-command": "^1.2 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,4 +51,14 @@
 		</properties>
 	</rule>
 
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/(Plugin_|Core_)?Command_Namespace\.php$</exclude-pattern>
+		<exclude-pattern>*/src/Checksum_(Plugin|Core|Base)_Command\.php$</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
+		<exclude-pattern>*/src/WP_CLI/Fetchers/UnfilteredPlugin\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-checksum">
+	<description>Custom ruleset for WP-CLI checksum-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Checksum"/><!-- Namespaces. -->
+				<element value="wpcli_checksum"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -53,7 +53,7 @@
 
 	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
-		<exclude-pattern>*/src/(Plugin_|Core_)?Command_Namespace\.php$</exclude-pattern>
+		<exclude-pattern>*/src/(Plugin_|Core_)Command_Namespace\.php$</exclude-pattern>
 		<exclude-pattern>*/src/Checksum_(Plugin|Core|Base)_Command\.php$</exclude-pattern>
 	</rule>
 

--- a/src/Checksum_Base_Command.php
+++ b/src/Checksum_Base_Command.php
@@ -1,6 +1,6 @@
 <?php
 
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * Base command that all checksum commands rely on.

--- a/src/Checksum_Base_Command.php
+++ b/src/Checksum_Base_Command.php
@@ -27,10 +27,15 @@ class Checksum_Base_Command extends WP_CLI_Command {
 	 *
 	 * @return mixed
 	 */
-	protected static function _read( $url ) {
+	protected static function _read( $url ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Could be used in classes extending this class.
 		$headers  = array( 'Accept' => 'application/json' );
-		$response = Utils\http_request( 'GET', $url, null, $headers,
-			array( 'timeout' => 30 ) );
+		$response = Utils\http_request(
+			'GET',
+			$url,
+			null,
+			$headers,
+			array( 'timeout' => 30 )
+		);
 		if ( 200 === $response->status_code ) {
 			return $response->body;
 		}
@@ -48,8 +53,10 @@ class Checksum_Base_Command extends WP_CLI_Command {
 		$filtered_files = array();
 		try {
 			$files = new RecursiveIteratorIterator(
-				new RecursiveDirectoryIterator( $path,
-					RecursiveDirectoryIterator::SKIP_DOTS ),
+				new RecursiveDirectoryIterator(
+					$path,
+					RecursiveDirectoryIterator::SKIP_DOTS
+				),
 				RecursiveIteratorIterator::CHILD_FIRST
 			);
 			foreach ( $files as $file_info ) {

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -9,22 +9,6 @@ use \WP_CLI\Utils;
  */
 class Checksum_Core_Command extends Checksum_Base_Command {
 
-	private function get_download_offer( $locale ) {
-		$out = unserialize( //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- WordPress itself uses these functions for the data being adjusted.
-			self::_read(
-				'https://api.wordpress.org/core/version-check/1.6/?locale=' . $locale
-			)
-		);
-
-		$offer = $out['offers'][0];
-
-		if ( $offer['locale'] !== $locale ) {
-			return false;
-		}
-
-		return $offer;
-	}
-
 	/**
 	 * Verifies WordPress files against WordPress.org's checksums.
 	 *

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -202,7 +202,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 */
 	private static function get_core_checksums( $version, $locale ) {
 		$query = http_build_query( compact( 'version', 'locale' ), null, '&' );
-		$url = "https://api.wordpress.org/core/checksums/1.0/?{$query}";
+		$url   = "https://api.wordpress.org/core/checksums/1.0/?{$query}";
 
 		$options = [ 'timeout' => 30 ];
 

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -201,7 +201,8 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * @return bool|array False on failure. An array of checksums on success.
 	 */
 	private static function get_core_checksums( $version, $locale ) {
-		$url = 'https://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), null, '&' );
+		$query = http_build_query( compact( 'version', 'locale' ), null, '&' );
+		$url = "https://api.wordpress.org/core/checksums/1.0/?{$query}";
 
 		$options = [ 'timeout' => 30 ];
 

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -1,6 +1,6 @@
 <?php
 
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * Verifies core file integrity by comparing to published checksums.
@@ -208,7 +208,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 		$headers  = [ 'Accept' => 'application/json' ];
 		$response = Utils\http_request( 'GET', $url, null, $headers, $options );
 
-		if ( ! $response->success || 200 !== intval( $response->status_code ) ) {
+		if ( ! $response->success || 200 !== (int) $response->status_code ) {
 			return false;
 		}
 

--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -269,7 +269,8 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 	 */
 	private function check_file_checksum( $path, $checksums ) {
 		if ( $this->supports_sha256()
-			&& array_key_exists( 'sha256', $checksums ) ) {
+			&& array_key_exists( 'sha256', $checksums )
+		) {
 			$sha256 = $this->get_sha256( $this->get_absolute_path( $path ) );
 
 			return in_array( $sha256, (array) $checksums['sha256'], true );

--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -269,7 +269,7 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 	 */
 	private function check_file_checksum( $path, $checksums ) {
 		if ( $this->supports_sha256()
-		     && array_key_exists( 'sha256', $checksums ) ) {
+			&& array_key_exists( 'sha256', $checksums ) ) {
 			$sha256 = $this->get_sha256( $this->get_absolute_path( $path ) );
 
 			return in_array( $sha256, (array) $checksums['sha256'], true );

--- a/src/WP_CLI/Fetchers/UnfilteredPlugin.php
+++ b/src/WP_CLI/Fetchers/UnfilteredPlugin.php
@@ -26,9 +26,9 @@ class UnfilteredPlugin extends Base {
 	 */
 	public function get( $name ) {
 		foreach ( get_plugins() as $file => $_ ) {
-			if ( $file === "$name.php" ||
+			if ( "$name.php" === $file ||
 				( $name && $file === $name ) ||
-				( dirname( $file ) === $name && $name !== '.' ) ) {
+				( dirname( $file ) === $name && '.' !== $name ) ) {
 				return (object) compact( 'name', 'file' );
 			}
 		}

--- a/src/WP_CLI/Fetchers/UnfilteredPlugin.php
+++ b/src/WP_CLI/Fetchers/UnfilteredPlugin.php
@@ -26,7 +26,7 @@ class UnfilteredPlugin extends Base {
 	 */
 	public function get( $name ) {
 		foreach ( get_plugins() as $file => $_ ) {
-			if ( "$name.php" === $file ||
+			if ( "{$name}.php" === $file ||
 				( $name && $file === $name ) ||
 				( dirname( $file ) === $name && '.' !== $name ) ) {
 				return (object) compact( 'name', 'file' );


### PR DESCRIPTION
Add a PHPCS ruleset using the new `WP_CLI_CS` standard.

Fixes #60 

Related https://github.com/wp-cli/wp-cli/issues/5179