### PR TITLE
Add preliminary PHP 7.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.2
+php: 7.3
 
 notifications:
   email:
@@ -51,6 +51,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.3
       env: WP_VERSION=latest
     - stage: test
@@ -75,3 +78,7 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -1,5 +1,6 @@
 Feature: Validate checksums for WordPress install
 
+  @require-php-5.6
   Scenario: Verify core checksums
     Given a WP install
 
@@ -73,6 +74,7 @@ Feature: Validate checksums for WordPress install
       """
     And the return code should be 0
 
+  @require-php-5.6
   Scenario: Verify core checksums with extra files
     Given a WP install
 


### PR DESCRIPTION
The testing step for PHP 7.4 is still allowed to fail for now while we prepare the code base for the upcoming release.