### PR TITLE
Prevent unnecessary directory recursion

### DIFF
--- a/src/Checksum_Base_Command.php
+++ b/src/Checksum_Base_Command.php
@@ -53,9 +53,13 @@ class Checksum_Base_Command extends WP_CLI_Command {
 		$filtered_files = array();
 		try {
 			$files = new RecursiveIteratorIterator(
-				new RecursiveDirectoryIterator(
-					$path,
-					RecursiveDirectoryIterator::SKIP_DOTS
+				new RecursiveCallbackFilterIterator(
+					new RecursiveDirectoryIterator(
+						$path,
+						RecursiveDirectoryIterator::SKIP_DOTS
+					), function($current, $key, $iterator) use($path) {
+						return $this->filter_file( self::normalize_directory_separators( substr( $current->getPathname(), strlen( $path ) ) ) );
+					}
 				),
 				RecursiveIteratorIterator::CHILD_FIRST
 			);

--- a/src/Checksum_Base_Command.php
+++ b/src/Checksum_Base_Command.php
@@ -57,7 +57,8 @@ class Checksum_Base_Command extends WP_CLI_Command {
 					new RecursiveDirectoryIterator(
 						$path,
 						RecursiveDirectoryIterator::SKIP_DOTS
-					), function($current, $key, $iterator) use($path) {
+					),
+					function ( $current, $key, $iterator ) use ( $path ) {
 						return $this->filter_file( self::normalize_directory_separators( substr( $current->getPathname(), strlen( $path ) ) ) );
 					}
 				),


### PR DESCRIPTION
The `wp core verify-checksums` command errantly makes a recursive directory listing of the entire ABSPATH, then iterates that listing and ignores any entries that don't match a very narrow filter (which, in practice, is basically wp-admin/, wp-includes/, and wp-*.php). On sites with millions of files (for example, lots of uploads in wp-content/uploads/ or unruly cache directories), the act of doing this unnecessary recursive directory listing takes multiple minutes to complete.

This pull request wraps the RecursiveDirectoryIterator in a RecursiveCallbackFilterIterator that mirrors the existing logic already used to exclude files or directories that are not relevant to the checksum verification. The results of the command are the exact same - but by limiting which directories the RecursiveDirectoryIterator goes in to using the existing filter, the command can complete in seconds as opposed to minutes or longer.

This request could be DRY'ed out, as it does build the files array using the filter and then iterates that array to perform almost the same filtering again, but I felt that submitting this simplified request would make it clear that the change here is minimal in scope and is nothing more than a speedup based on the existing code.

On a test site with 4 million files in wp-content and other non-WordPress directories, the original version (with the erroneous recursion) takes about 1min 39sec to complete `wp core verify-checksums`. This modified version finished in 0.5sec while still identifying the same files that should not exist.