### PR TITLE
Fix failing checksum tests due to timeout on `WP_VERSION=trunk`

### DIFF
--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -57,7 +57,7 @@ Feature: Validate checksums for WordPress install
       """
 
   Scenario: Verify core checksums for a non US local
-    Given a WP install
+    Given an empty directory
     # If current WP_VERSION is nightly, trunk or old then from checksum might not exist, so STDERR may or may not be empty.
     And I try `wp core download --locale=en_GB --version=4.3.1 --force`
     Then STDOUT should contain:

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -58,16 +58,14 @@ Feature: Validate checksums for WordPress install
 
   Scenario: Verify core checksums for a non US local
     Given an empty directory
-    # If current WP_VERSION is nightly, trunk or old then from checksum might not exist, so STDERR may or may not be empty.
-    And I try `wp core download --locale=en_GB --version=4.3.1 --force`
+    And I run `wp core download --locale=en_GB --version=4.3.1 --force`
     Then STDOUT should contain:
       """
       Success: WordPress downloaded.
       """
     And the return code should be 0
 
-    # Similarly if current WP_VERSION is nightly, trunk or old then will get "File should not exist" warnings, so STDERR may or may not be empty.
-    When I try `wp core verify-checksums`
+    When I run `wp core verify-checksums`
     Then STDOUT should be:
       """
       Success: WordPress installation verifies against checksums.


### PR DESCRIPTION
The test was originally added in https://github.com/wp-cli/wp-cli/pull/2287 and further updated in https://github.com/wp-cli/checksum-command/pull/16

For this particular test scenario, it's perfectly fine to start with `Given an empty directory`. The test is for an earlier version of WordPress with a specific locale. It doesn't test trunk behavior at all.