### PR TITLE
Add --include-root parameter to also verify root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package implements the following commands:
 Verifies WordPress files against WordPress.org's checksums.
 
 ~~~
-wp core verify-checksums [--version=<version>] [--locale=<locale>] [--insecure]
+wp core verify-checksums [--include-root] [--version=<version>] [--locale=<locale>] [--insecure]
 ~~~
 
 Downloads md5 checksums for the current version from WordPress.org, and
@@ -30,6 +30,9 @@ the values from the `Dashboard->Updates` menu in the admin area of the
 site.
 
 **OPTIONS**
+
+	[--include-root]
+		Verify all files and folders in the root directory, and warn if any non-WordPress items are found.
 
 	[--version=<version>]
 		Verify checksums against a specific version of WordPress.

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -27,7 +27,7 @@ Feature: Validate checksums for WordPress install
     When I run `rm readme.html`
     Then STDERR should be empty
 
-    When I try `wp core verify-checksums`
+    When I run `wp core verify-checksums`
     Then STDOUT should be:
       """
       Success: WordPress installation verifies against checksums.

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -138,7 +138,6 @@ Feature: Validate checksums for WordPress install
       """
     And the return code should be 0
 
-  @daniel
   Scenario: Verify core checksums when extra files are included in WordPress root and --include-root is passed
     Given a WP install
     And a extra-file.php file:

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -120,41 +120,41 @@ Feature: Validate checksums for WordPress install
       """
     And the return code should be 0
 
-    Scenario: Verify core checksums when extra files prefixed with 'wp-' are included in WordPress root
-      Given a WP install
-      And a wp-extra-file.php file:
-        """
-        hello world
-        """
+  Scenario: Verify core checksums when extra files prefixed with 'wp-' are included in WordPress root
+    Given a WP install
+    And a wp-extra-file.php file:
+      """
+      hello world
+      """
 
-      When I try `wp core verify-checksums`
-      Then STDERR should be:
-        """
-        Warning: File should not exist: wp-extra-file.php
-        """
-      And STDOUT should be:
-        """
-        Success: WordPress installation verifies against checksums.
-        """
-      And the return code should be 0
+    When I try `wp core verify-checksums`
+    Then STDERR should be:
+      """
+      Warning: File should not exist: wp-extra-file.php
+      """
+    And STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+    And the return code should be 0
 
-    Scenario: Verify core checksums when extra files are included in WordPress root and --include-root is passed
-      Given a WP install
-      And a extra-file.php file:
-        """
-        hello world
-        """
+  Scenario: Verify core checksums when extra files are included in WordPress root and --include-root is passed
+    Given a WP install
+    And a extra-file.php file:
+      """
+      hello world
+      """
 
-      When I try `wp core verify-checksums --include-root`
-      Then STDERR should be:
-        """
-        Warning: File should not exist: extra-file.php
-        """
-      And STDOUT should be:
-        """
-        Success: WordPress installation verifies against checksums.
-        """
-      And the return code should be 0
+    When I try `wp core verify-checksums --include-root`
+    Then STDERR should be:
+      """
+      Warning: File should not exist: extra-file.php
+      """
+    And STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+    And the return code should be 0
 
   Scenario: Verify core checksums with a plugin that has wp-admin
     Given a WP install

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -159,9 +159,12 @@ Feature: Validate checksums for WordPress install
       """
 
     When I try `wp core verify-checksums --include-root`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Warning: File should not exist: unknown-folder/unknown-file.php
+      """
+    And STDERR should contain:
+      """
       Warning: File should not exist: extra-file.php
       """
     And STDERR should not contain:
@@ -177,9 +180,15 @@ Feature: Validate checksums for WordPress install
     When I run `wp core verify-checksums`
     Then STDERR should not contain:
       """
-      Warning: File should not exist: wp-content/unknown-file.php
       Warning: File should not exist: unknown-folder/unknown-file.php
+      """
+    And STDERR should not contain:
+      """
       Warning: File should not exist: extra-file.php
+      """
+    And STDERR should not contain:
+      """
+      Warning: File should not exist: wp-content/unknown-file.php
       """
     And STDOUT should be:
       """

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -138,16 +138,43 @@ Feature: Validate checksums for WordPress install
       """
     And the return code should be 0
 
+  @daniel
   Scenario: Verify core checksums when extra files are included in WordPress root and --include-root is passed
     Given a WP install
     And a extra-file.php file:
       """
       hello world
       """
+    And a unknown-folder/unknown-file.php file:
+      """
+      taco burrito
+      """
+    And a wp-content/unknown-file.php file:
+      """
+      foobar
+      """
 
     When I try `wp core verify-checksums --include-root`
     Then STDERR should be:
       """
+      Warning: File should not exist: unknown-folder/unknown-file.php
+      Warning: File should not exist: extra-file.php
+      """
+    And STDERR should not contain:
+      """
+      Warning: File should not exist: wp-content/unknown-file.php
+      """
+    And STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+    And the return code should be 0
+
+    When I run `wp core verify-checksums`
+    Then STDERR should not contain:
+      """
+      Warning: File should not exist: wp-content/unknown-file.php
+      Warning: File should not exist: unknown-folder/unknown-file.php
       Warning: File should not exist: extra-file.php
       """
     And STDOUT should be:

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -28,6 +28,30 @@ Feature: Validate checksums for WordPress install
     Then STDERR should be empty
 
     When I try `wp core verify-checksums`
+    Then STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+
+  Scenario: Core checksums don't verify because wp-cli.yml is present
+    Given a WP install
+    And a wp-cli.yml file is present
+
+    When I try `wp core verify-checksums`
+    Then STDERR should be:
+      """
+      Warning: File should not exist: wp-includes/extra-file.txt
+      """
+    And STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+    And the return code should be 0
+
+    When I run `rm wp-cli.yml`
+    Then STDERR should be empty
+
+    When I try `wp core verify-checksums`
     Then STDERR should be:
       """
       Warning: File doesn't exist: readme.html

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -114,6 +114,24 @@ Feature: Validate checksums for WordPress install
         """
       And the return code should be 0
 
+    Scenario: Verify core checksums when extra files are included in WordPress root and --include-root is passed
+      Given a WP install
+      And a extra-file.php file:
+        """
+        hello world
+        """
+
+      When I try `wp core verify-checksums --include-root`
+      Then STDERR should be:
+        """
+        Warning: File should not exist: extra-file.php
+        """
+      And STDOUT should be:
+        """
+        Success: WordPress installation verifies against checksums.
+        """
+      And the return code should be 0
+
   Scenario: Verify core checksums with a plugin that has wp-admin
     Given a WP install
     And a wp-content/plugins/akismet/wp-admin/extra-file.txt file:

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -27,11 +27,13 @@ Feature: Validate checksums for WordPress install
     When I run `rm readme.html`
     Then STDERR should be empty
 
-    When I run `wp core verify-checksums`
-    Then STDOUT should be:
+    When I try `wp core verify-checksums`
+    Then STDERR should be:
       """
-      Success: WordPress installation verifies against checksums.
+      Warning: File doesn't exist: readme.html
+      Error: WordPress installation doesn't verify against checksums.
       """
+    And the return code should be 1
 
   Scenario: Core checksums don't verify because wp-cli.yml is present
     Given a WP install

--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -35,12 +35,16 @@ Feature: Validate checksums for WordPress install
 
   Scenario: Core checksums don't verify because wp-cli.yml is present
     Given a WP install
-    And a wp-cli.yml file is present
+    And a wp-cli.yml file:
+      """
+      plugin install:
+        - user-switching
+      """
 
     When I try `wp core verify-checksums`
     Then STDERR should be:
       """
-      Warning: File should not exist: wp-includes/extra-file.txt
+      Warning: File should not exist: wp-cli.yml
       """
     And STDOUT should be:
       """
@@ -51,12 +55,13 @@ Feature: Validate checksums for WordPress install
     When I run `rm wp-cli.yml`
     Then STDERR should be empty
 
-    When I try `wp core verify-checksums`
-    Then STDERR should be:
+    When I run `wp core verify-checksums`
+    Then STDERR should be empty
+    And STDOUT should be:
       """
-      Warning: File doesn't exist: readme.html
-      Error: WordPress installation doesn't verify against checksums.
+      Success: WordPress installation verifies against checksums.
       """
+    And the return code should be 0
 
   Scenario: Verify core checksums without loading WordPress
     Given an empty directory

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -149,7 +149,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 *
 	 * @return bool
 	 */
-	protected function filter_file( $filepath, $include_root = false ) {
+	protected function filter_file( $filepath ) {
 		if ( true === $this->include_root ) {
 			return ( 1 !== preg_match( '/^(wp-config\.php$|wp-content\/)/', $filepath ) );
 		}

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -145,7 +145,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 */
 	protected function filter_file( $filepath, $include_root = false ) {
 		if ( true === $this->include_root ) {
-			return ( 1 !== preg_match( '/^(wp-config\.php|wp-content\/plugins)$/', $filepath ) );
+			return ( 1 !== preg_match( '/^(wp-config\.php$|wp-content\/)/', $filepath ) );
 		}
 
 		return ( 0 === strpos( $filepath, 'wp-admin/' )

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -61,8 +61,8 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * @when before_wp_load
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		$wp_version   = '';
-		$locale       = '';
+		$wp_version         = '';
+		$locale             = '';
 		$this->include_root = false;
 
 		if ( ! empty( $assoc_args['version'] ) ) {

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -145,7 +145,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 */
 	protected function filter_file( $filepath, $include_root = false ) {
 		if ( true === $this->include_root ) {
-			return true;
+			return ( 1 !== preg_match( '/^(wp-config\.php|wp-content\/plugins)$/', $filepath ) );
 		}
 
 		return ( 0 === strpos( $filepath, 'wp-admin/' )

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -11,6 +11,13 @@ use WP_CLI\WpOrgApi;
 class Checksum_Core_Command extends Checksum_Base_Command {
 
 	/**
+	 * Whether or not to verify contents of the root directory.
+	 *
+	 * @var boolean
+	 */
+	private $include_root = false;
+
+	/**
 	 * Verifies WordPress files against WordPress.org's checksums.
 	 *
 	 * Downloads md5 checksums for the current version from WordPress.org, and
@@ -61,9 +68,8 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * @when before_wp_load
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		$wp_version         = '';
-		$locale             = '';
-		$this->include_root = false;
+		$wp_version = '';
+		$locale     = '';
 
 		if ( ! empty( $assoc_args['version'] ) ) {
 			$wp_version = $assoc_args['version'];

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -26,7 +26,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * ## OPTIONS
 	 *
 	 * [--include-root]
-	 * : Verify all files in the root directory.
+	 * : Verify all files in the root directory, and warn if any non-WordPress files are found.
 	 *
 	 * [--version=<version>]
 	 * : Verify checksums against a specific version of WordPress.

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -33,7 +33,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * ## OPTIONS
 	 *
 	 * [--include-root]
-	 * : Verify all files in the root directory, and warn if any non-WordPress files are found.
+	 * : Verify all files and folders in the root directory, and warn if any non-WordPress items are found.
 	 *
 	 * [--version=<version>]
 	 * : Verify checksums against a specific version of WordPress.

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -25,6 +25,9 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--include-root]
+	 * : Verify all files in the root directory.
+	 *
 	 * [--version=<version>]
 	 * : Verify checksums against a specific version of WordPress.
 	 *
@@ -58,8 +61,9 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 * @when before_wp_load
 	 */
 	public function __invoke( $args, $assoc_args ) {
-		$wp_version = '';
-		$locale     = '';
+		$wp_version   = '';
+		$locale       = '';
+		$this->include_root = false;
 
 		if ( ! empty( $assoc_args['version'] ) ) {
 			$wp_version = $assoc_args['version'];
@@ -67,6 +71,10 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 
 		if ( ! empty( $assoc_args['locale'] ) ) {
 			$locale = $assoc_args['locale'];
+		}
+
+		if ( ! empty( $assoc_args['include-root'] ) ) {
+			$this->include_root = true;
 		}
 
 		if ( empty( $wp_version ) ) {
@@ -135,7 +143,11 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 *
 	 * @return bool
 	 */
-	protected function filter_file( $filepath ) {
+	protected function filter_file( $filepath, $include_root = false ) {
+		if ( true === $this->include_root ) {
+			return true;
+		}
+
 		return ( 0 === strpos( $filepath, 'wp-admin/' )
 			|| 0 === strpos( $filepath, 'wp-includes/' )
 			|| 1 === preg_match( '/^wp-(?!config\.php)([^\/]*)$/', $filepath )


### PR DESCRIPTION
## Description
Add `--include-root` parameter. Allows warning for unexpected files in `ABSPATH`.

### Related Issues
Fixes #81, Fixes #74.