### PR TITLE
Log warning if `WpOrgApi::get_plugin_checksums()` fails

### DIFF
--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -101,6 +101,7 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 			try {
 				$checksums = $wp_org_api->get_plugin_checksums( $plugin->name, $version );
 			} catch ( Exception $exception ) {
+				WP_CLI::warning( $exception->getMessage() );
 				$checksums = false;
 			}
 


### PR DESCRIPTION
`WpOrgApi::get_plugin_checksums()` throws exception if failed to fetch checksums (e.g. network issues, wrong URL). In these cases at least a warning should be logged to add a hint about the error and save 90% of debug time.
