### PR TITLE
Don't warn about .htaccess file when --include-root is used

### DIFF
--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -151,7 +151,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 	 */
 	protected function filter_file( $filepath ) {
 		if ( true === $this->include_root ) {
-			return ( 1 !== preg_match( '/^(wp-config\.php$|wp-content\/)/', $filepath ) );
+			return ( 1 !== preg_match( '/^(\.htaccess$|wp-config\.php$|wp-content\/)/', $filepath ) );
 		}
 
 		return ( 0 === strpos( $filepath, 'wp-admin/' )


### PR DESCRIPTION
### Description
Don't warn about `.htaccess` file when `--include-root` is used.