### PR TITLE
Add blank space when trimming the version

### DIFF
--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -241,6 +241,6 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 
 		$value = substr( $code, $start, $end - $start );
 
-		return trim( $value, "'" );
+		return trim( $value, " '" );
 	}
 }


### PR DESCRIPTION
The `verify-checksum` command relies on the method `find_var` to get the WordPress version to check against. The version currently comes with an extra space which causes an additional character when performing the HTTP request to https://api.wordpress.org/core/checksums/1.0/.

Example HTTP request performed by `verify-checksums`:
```
https://api.wordpress.org/core/checksums/1.0/?version=%206.2.2
```
How it should look like:
```
https://api.wordpress.org/core/checksums/1.0/?version=6.2.2
```

Hope this saves some striping in the server.