### PR TITLE
Plugin Checksums: Don't check missing files

### DIFF
--- a/features/checksum-plugin.feature
+++ b/features/checksum-plugin.feature
@@ -20,17 +20,6 @@ Feature: Validate checksums for WordPress plugins
       """
     And STDERR should be empty
 
-    When I try `wp plugin verify-checksums duplicate-post --format=json --version=3.2.2`
-    Then the return code should be 1
-    And STDOUT should contain:
-      """
-      "plugin_name":"duplicate-post","file":"duplicate-post-jetpack.php","message":"File is missing"
-      """
-    And STDERR should be:
-      """
-      Error: No plugins verified (1 failed).
-      """
-
   Scenario: Modified plugin doesn't verify
     Given a WP install
 
@@ -44,19 +33,6 @@ Feature: Validate checksums for WordPress plugins
     Then STDOUT should contain:
       """
       "plugin_name":"duplicate-post","file":"duplicate-post.php","message":"Checksum does not match"
-      """
-    And STDERR should be:
-      """
-      Error: No plugins verified (1 failed).
-      """
-
-    When I run `rm wp-content/plugins/duplicate-post/duplicate-post.css`
-    Then STDERR should be empty
-
-    When I try `wp plugin verify-checksums duplicate-post --format=json`
-    Then STDOUT should contain:
-      """
-      "plugin_name":"duplicate-post","file":"duplicate-post.css","message":"File is missing"
       """
     And STDERR should be:
       """

--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -133,12 +133,6 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 
 			$files = $this->get_plugin_files( $plugin->file );
 
-			foreach ( $checksums as $file => $checksum_array ) {
-				if ( ! in_array( $file, $files, true ) ) {
-					$this->add_error( $plugin->name, $file, 'File is missing' );
-				}
-			}
-
 			foreach ( $files as $file ) {
 				if ( ! array_key_exists( $file, $checksums ) ) {
 					$this->add_error( $plugin->name, $file, 'File was added' );


### PR DESCRIPTION
Per #46 the checksum command is currently checking for missing files.

The current Plugin checksums do not have this information, causing the plugin checksum command to incorrectly fail.

This will be possible some day, when https://meta.trac.wordpress.org/ticket/6275 is resolved.

For now, this removes the functionality from the command.