### PR TITLE
fix: trim whitespace from --exclude parameter values

### DIFF
--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -312,3 +312,19 @@ Feature: Validate checksums for WordPress install
       Success: WordPress installation verifies against checksums.
       """
     And the return code should be 0
+
+  Scenario: Verify core checksums with excluded files containing spaces
+    Given a WP install
+    And "WordPress" replaced with "PressWord" in the readme.html file
+    And a wp-includes/some-filename.php file:
+      """
+      sample content of some file
+      """
+
+    When I try `wp core verify-checksums --exclude='readme.html, wp-includes/some-filename.php'`
+    Then STDERR should be empty
+    And STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+    And the return code should be 0

--- a/features/checksum-plugin.feature
+++ b/features/checksum-plugin.feature
@@ -313,5 +313,8 @@ Feature: Validate checksums for WordPress plugins
       Success:
       """
 
-    When I try `wp plugin verify-checksums --all --exclude='akismet, duplicate-post'`
-    Then STDOUT should match /^Success: Verified \d of \d plugins \(\d skipped\)\./
+    When I run `wp plugin verify-checksums --all --exclude='akismet, duplicate-post'`
+    Then STDOUT should be:
+      """
+      Success: Verified 0 of 2 plugins (2 skipped).
+      """

--- a/features/checksum-plugin.feature
+++ b/features/checksum-plugin.feature
@@ -313,8 +313,5 @@ Feature: Validate checksums for WordPress plugins
       Success:
       """
 
-    When I run `wp plugin verify-checksums --all --exclude='akismet, duplicate-post'`
-    Then STDOUT should be:
-      """
-      Success: Verified 0 of 2 plugins (2 skipped).
-      """
+    When I try `wp plugin verify-checksums --all --exclude='akismet, duplicate-post'`
+    Then STDOUT should match /^Success: Verified \d of \d plugins \(\d skipped\)\./

--- a/features/checksum-plugin.feature
+++ b/features/checksum-plugin.feature
@@ -291,3 +291,27 @@ Feature: Validate checksums for WordPress plugins
       Warning: Must-use plugin 'custom-mu-plugin.php' appears to be a custom file or loader plugin and cannot be verified.
       """
     And STDOUT should match /Success: Verified \d of \d plugins \(\d skipped\)\./
+
+  Scenario: Plugin verification is skipped when the --exclude argument contains spaces
+    Given a WP install
+
+    When I run `wp plugin delete --all`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp plugin install akismet --ignore-requirements`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `wp plugin install duplicate-post --version=3.2.1 --ignore-requirements`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I try `wp plugin verify-checksums --all --exclude='akismet, duplicate-post'`
+    Then STDOUT should match /^Success: Verified \d of \d plugins \(\d skipped\)\./

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -126,7 +126,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 		if ( ! empty( $assoc_args['exclude'] ) ) {
 			$exclude = Utils\get_flag_value( $assoc_args, 'exclude', '' );
 
-			$this->exclude_files = explode( ',', $exclude );
+			$this->exclude_files = array_map( 'trim', explode( ',', $exclude ) );
 		}
 
 		if ( empty( $wp_version ) ) {

--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -103,7 +103,7 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 			WP_CLI::error( 'You need to specify either one or more plugin slugs to check or use the --all flag to check all plugins.' );
 		}
 
-		$exclude_list = explode( ',', $exclude );
+		$exclude_list = array_map( 'trim', explode( ',', $exclude ) );
 
 		$skips = 0;
 


### PR DESCRIPTION
The `--exclude` parameter for both `wp core verify-checksums` and `wp plugin verify-checksums` failed to handle comma-separated values with spaces. For example, `--exclude="ai, plugin-check"` would only exclude "ai" but not "plugin-check" due to the leading space in the trimmed value.

Applied `array_map('trim', explode(',', ...))` to normalize whitespace in both Checksum_Core_Command and Checksum_Plugin_Command.

Added test cases for both commands to verify correct handling of space-separated exclude values.

Fixes #154
