### PR TITLE
Trim whitespace from --exclude entries in core and plugin verify-checksums

### DIFF
--- a/features/checksum-core.feature
+++ b/features/checksum-core.feature
@@ -312,3 +312,19 @@ Feature: Validate checksums for WordPress install
       Success: WordPress installation verifies against checksums.
       """
     And the return code should be 0
+
+  Scenario: Verify core checksums with excluded files containing whitespace around comma separators
+    Given a WP install
+    And "WordPress" replaced with "PressWord" in the readme.html file
+    And a wp-includes/some-filename.php file:
+      """
+      sample content of some file
+      """
+
+    When I try `wp core verify-checksums --exclude='readme.html, wp-includes/some-filename.php'`
+    Then STDERR should be empty
+    And STDOUT should be:
+      """
+      Success: WordPress installation verifies against checksums.
+      """
+    And the return code should be 0

--- a/features/checksum-plugin.feature
+++ b/features/checksum-plugin.feature
@@ -153,6 +153,25 @@ Feature: Validate checksums for WordPress plugins
     When I try `wp plugin verify-checksums --all --exclude=akismet`
     Then STDOUT should match /^Success: Verified \d of \d plugins \(\d skipped\)\./
 
+  Scenario: Plugin verification is skipped when --exclude entries have surrounding whitespace
+    Given a WP install
+
+    When I run `wp plugin delete --all`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    # Ignore plugin's version requirements because we don't actually activate it.
+    When I run `wp plugin install akismet --ignore-requirements`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I try `wp plugin verify-checksums --all --exclude=' akismet'`
+    Then STDOUT should match /^Success: Verified \d of \d plugins \(\d skipped\)\./
+
   Scenario: Plugin is verified when the --exclude argument isn't included
     Given a WP install
 

--- a/src/Checksum_Core_Command.php
+++ b/src/Checksum_Core_Command.php
@@ -126,7 +126,7 @@ class Checksum_Core_Command extends Checksum_Base_Command {
 		if ( ! empty( $assoc_args['exclude'] ) ) {
 			$exclude = Utils\get_flag_value( $assoc_args, 'exclude', '' );
 
-			$this->exclude_files = explode( ',', $exclude );
+			$this->exclude_files = array_map( 'trim', explode( ',', $exclude ) );
 		}
 
 		if ( empty( $wp_version ) ) {

--- a/src/Checksum_Plugin_Command.php
+++ b/src/Checksum_Plugin_Command.php
@@ -103,7 +103,7 @@ class Checksum_Plugin_Command extends Checksum_Base_Command {
 			WP_CLI::error( 'You need to specify either one or more plugin slugs to check or use the --all flag to check all plugins.' );
 		}
 
-		$exclude_list = explode( ',', $exclude );
+		$exclude_list = array_map( 'trim', explode( ',', $exclude ) );
 
 		$skips = 0;
 


### PR DESCRIPTION
## Summary

- `explode( ',', $exclude )` in both `Checksum_Core_Command` and `Checksum_Plugin_Command` produces entries with leading/trailing spaces when the user writes a comma-separated list with spaces (e.g. `"a, b, c"`).
- The downstream `in_array( ..., true )` strict comparison means `' b' !== 'b'`, so those entries silently match nothing.
- Fix: wrap with `array_map( 'trim', ... )` so `"a, b"` and `"a,b"` behave identically.

## Changes

- `src/Checksum_Core_Command.php` line 129: `array_map( 'trim', explode( ',', $exclude ) )`
- `src/Checksum_Plugin_Command.php` line 106: `array_map( 'trim', explode( ',', $exclude ) )`
- `features/checksum-core.feature`: new scenario covering spaced exclude list
- `features/checksum-plugin.feature`: new scenario covering leading-space exclude entry

## Testing

```bash
# Before fix — only "readme.html" skipped, "wp-includes/some-filename.php" not excluded
wp core verify-checksums --exclude='readme.html, wp-includes/some-filename.php'

# After fix — both excluded, command succeeds
wp core verify-checksums --exclude='readme.html, wp-includes/some-filename.php'
```

Functional tests added in both `.feature` files covering the whitespace case.

Fixes: `--exclude` does not trim whitespace, so space-separated entries are silently not excluded.